### PR TITLE
Handled case for missing '\n' char in .bashrc

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -39,4 +39,4 @@ make -j4 all-target-libgcc
 make -j4 install-gcc
 make -j4 install-target-libgcc
 
-echo "export PATH=\"\$HOME/opt/cross/bin:\$PATH\"" >> $HOME/.bashrc
+echo -e "\nexport PATH=\"\$PATH:\$HOME/opt/cross/bin\"" >> $HOME/.bashrc


### PR DESCRIPTION
If '\n' char is missing at the end in .bashrc,
the previous command to add PATH will append onto
the last command in the .bashrc file