### PR TITLE
Bug Fix In kernal/kernal/kshell.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 disk.img
 build/*
 Experiment
+.vscode

--- a/kernel/kernel/kshell.c
+++ b/kernel/kernel/kshell.c
@@ -387,10 +387,12 @@ static void command_quote()
 }
 static void string_copy(char* strd,char* strs)
 {
-	for(int i=0;strs[i];i++)
+	int i=0;
+	for(;strs[i];i++)
 	{
 		strd[i]=strs[i];
 	}
+	strd[i]='\0';
 }
 
 static bool string_compare(char* str1, char* str2)


### PR DESCRIPTION
Fixed A Bug In The string_copy(char* ,char* ) function

If the initial length of strd was longer(due to garbage value/the pointer was used for some other purpose) than strs the function did not give the desired behavior
Suppose strd="Master" and strs="Yoda" the function will give strd="Yodaer" which is not the desired result.
This was fixed by putting a null character at the end to mark the end of the strd.
Thus the strd after the Bug fix will be strd="Yoda\0r" which for all purposes will act as strd="Yoda"